### PR TITLE
Use globby for globbing, support _ and $ in js variable names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 const FS   = require('fs')
-const Path = require('path')
-const r1   = /^(let|var|const) +([a-zA-Z][a-zA-Z0-9]*) +\= +(require)\((('|")[a-zA-Z0-9-_.\/]+('|"))\)/gm
-const r2   = /^(let|var|const) +([a-zA-Z][a-zA-Z0-9]*) +\= +(require)\((('|")[a-zA-Z0-9-_.\/]+('|"))\)\.([a-zA-Z][a-zA-Z0-9]+)/gm
+const globby = require("globby");
+const r1   = /^(let|var|const) +([a-zA-Z_$][a-zA-Z0-9_$]*) +\= +(require)\((('|")[a-zA-Z0-9-_.\/]+('|"))\)/gm
+const r2   = /^(let|var|const) +([a-zA-Z_$][a-zA-Z0-9_$]*) +\= +(require)\((('|")[a-zA-Z0-9-_.\/]+('|"))\)\.([a-zA-Z][a-zA-Z0-9]+)/gm
 
 const args = process.argv.slice(2)
 
@@ -12,14 +12,20 @@ if (!args.length) {
   process.exit(1)
 }
 
-args.forEach(function (p) {
-  !p.match(/\/$/) && console.info(`Skipping ${p}, not a directory`)
-  FS.readdirSync(p)
-    .map(function (n) { return Path.join(p, n) })
-    .forEach(function (fp) {
-      if (FS.statSync(fp).isDirectory()) return null
-      return FS.writeFileSync(fp, FS.readFileSync(fp, 'utf-8')
-        .replace(r2, `import { $7 as $2 } from $4;`)
-        .replace(r1, `import $2 from $4`), 'utf-8')})})
+const paths = globby.sync(args);
+
+paths.forEach(function (p) {
+  if (!FS.statSync(p).isDirectory()) {
+    return replaceInFile(p)
+  }
+})
+
+function replaceInFile(fp) {
+  const result = FS.writeFileSync(fp, FS.readFileSync(fp, 'utf-8')
+    .replace(r2, `import { $7 as $2 } from $4;`)
+    .replace(r1, `import $2 from $4`), 'utf-8')
+  console.log(`> ${fp}`)
+  return result;
+}
 
 console.info('Done!\n')

--- a/package.json
+++ b/package.json
@@ -22,8 +22,14 @@
   },
   "author": "James J. Womack (@james_womack)",
   "license": "MIT",
+  "contributors": [
+    "Ole Morten Didriksen (@oledid)"
+  ],
   "bugs": {
     "url": "https://github.com/jameswomack/replace-require-with-import/issues"
   },
-  "homepage": "https://github.com/jameswomack/replace-require-with-import#readme"
+  "homepage": "https://github.com/jameswomack/replace-require-with-import#readme",
+  "dependencies": {
+    "globby": "^6.0.0"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # replace-require-with-import
 
-# do it
+## How to use
 ```
-npm i replace-require-with-import -g
-require2import ./src/**/
+npm install -g replace-require-with-import
+require2import ./src/**/*.js
 ```


### PR DESCRIPTION
Now supports `const $ = require("jquery");` and `const _ =
require("lodash");`

I also did not get your globbing to work on Windows, so I had to call require2import for each of the folders in my project, which was cumbersome. So I fixed this by using globby.

Tried to keep the original coding style.
