### PR TITLE
use diff to show test problems

### DIFF
--- a/test
+++ b/test
@@ -3,15 +3,16 @@
 cp test-input.js test-output.js
 
 ./index.js test-output.js
+status=$?
 
-output=`cat test-output.js`
-expected_output=`cat test-expected-output.js`
+diff ./test-expected-output.js ./test-output.js
+status=$?
 
-if [ "$output" == "$expected_output" ]; then
+if [ $status -eq 0 ]; then
   echo "Success!"
   rm test-output.js
   exit 0
-else
+else 
   echo "Failed :("
   rm test-output.js
   exit -1


### PR DESCRIPTION
I needed to change the `test` script, because it kept showing fails without anything being different.(Maybe linefeed?)

Now diffs are shown visual.